### PR TITLE
Switch to glob for play uploads.

### DIFF
--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -66,7 +66,7 @@ jobs:
                 with:
                     serviceAccountJson: service_account.json
                     packageName: com.inkapplications.glassconsole
-                    releaseFile: build/output/GlassConsole-${{ github.ref_name }}.aab
+                    releaseFiles: build/output/GlassConsole-*.aab
                     track: internal
     create-release:
         name: Draft Github Release


### PR DESCRIPTION
It looks like the new update on this doesn't support variable substitutions in the same way. Just switching this over to a glob instead.